### PR TITLE
Fix Vulkan CPU/GPU synchronization

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1359,6 +1359,8 @@ ProjectSettings::ProjectSettings() {
 	// Keep the enum values in sync with the `DisplayServer::VSyncMode` enum.
 	custom_prop_info["display/window/vsync/vsync_mode"] = PropertyInfo(Variant::INT, "display/window/vsync/vsync_mode", PROPERTY_HINT_ENUM, "Disabled,Enabled,Adaptive,Mailbox");
 	custom_prop_info["rendering/driver/threads/thread_model"] = PropertyInfo(Variant::INT, "rendering/driver/threads/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "display/window/vsync/buffer_count", PROPERTY_HINT_RANGE, "1,3,1"), 2);
+	GLOBAL_DEF_RST(PropertyInfo(Variant::INT, "display/window/vsync/swapchain_count", PROPERTY_HINT_RANGE, "1,4,1"), 3);
 	GLOBAL_DEF("physics/2d/run_on_separate_thread", false);
 	GLOBAL_DEF("physics/3d/run_on_separate_thread", false);
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -830,6 +830,23 @@
 		<member name="display/window/subwindows/embed_subwindows" type="bool" setter="" getter="" default="true">
 			If [code]true[/code] subwindows are embedded in the main window.
 		</member>
+		<member name="display/window/vsync/buffer_count" type="int" setter="" getter="" default="2">
+			Sets the number of buffers before stalling to wait for the GPU.
+			1 may give you the lowest lag/latency but at the high cost of no parallelism between CPU &amp; GPU.
+			Try the [url=https://darksylinc.github.io/vsync_simulator/]V-Sync Simulator[/url], an interactive interface that simulates presentation to better understand how it is affected by different variables under various conditions.
+			[b]Note:[/b] This setting is not supported by all APIs.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
+		</member>
+		<member name="display/window/vsync/swapchain_count" type="int" setter="" getter="" default="3">
+			Sets the number of swapchains (back buffer + front buffer).
+			[code]2[/code] corresponds to double buffering and [code]3[/code] to triple buffering. A value of [code]1[/code] is not recommended.
+			Double buffering may give you the lowest lag/latency but if VSync is on and the system can't render at 60 fps, the framerate will go down in multiples of it (e.g. 30 fps, 15, 7.5, etc ). Triple buffering gives you higher framerate (specially if the system can't reach a constant 60 fps) at the cost of up to 1 frame of latency (when VSync is On in FIFO mode).
+			Use Double buffering if V-Sync is off. Triple buffering is a must if you plan on using V-Sync MAILBOX mode.
+			Try the [url=https://darksylinc.github.io/vsync_simulator/]V-Sync Simulator[/url], an interactive interface that simulates presentation to better understand how it is affected by different variables under various conditions.
+			[b]Note:[/b] This setting is not supported by all APIs.
+			[b]Note:[/b] This property is only read when the project starts. There is currently no way to change this value at run-time.
+			[b]Note:[/b] Some platforms may restrict the actual value.
+		</member>
 		<member name="display/window/vsync/vsync_mode" type="int" setter="" getter="" default="1">
 			Sets the V-Sync mode for the main game window.
 			See [enum DisplayServer.VSyncMode] for possible values and how they affect the behavior of your application.

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1038,13 +1038,11 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	uint32_t max_timestamp_query_elements = 0;
 
 	TightLocalVector<Frame> frames; // Frames available, for main device they are cycled (usually 3), for local devices only 1.
-	int frame = 0; // Current frame.
-	int frame_count = 0; // Total amount of frames.
 	uint64_t frames_drawn = 0;
 	RID local_device;
 	bool local_device_processing = false;
 
-	void _free_pending_resources(int p_frame);
+	void _free_pending_resources(uint32_t p_frame);
 
 	VmaAllocator allocator = nullptr;
 	HashMap<uint32_t, VmaPool> small_allocs_pools;

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -97,7 +97,7 @@ private:
 	enum {
 		MAX_EXTENSIONS = 128,
 		MAX_LAYERS = 64,
-		FRAME_LAG = 2
+		MAX_FRAME_LAG = 4
 	};
 
 	static VulkanHooks *vulkan_hooks;
@@ -135,10 +135,15 @@ private:
 	VkQueue present_queue = VK_NULL_HANDLE;
 	VkColorSpaceKHR color_space;
 	VkFormat format;
-	VkSemaphore draw_complete_semaphores[FRAME_LAG];
-	VkSemaphore image_ownership_semaphores[FRAME_LAG];
-	int frame_index = 0;
-	VkFence fences[FRAME_LAG];
+	VkSemaphore draw_complete_semaphores[MAX_FRAME_LAG] = {};
+	VkSemaphore image_ownership_semaphores[MAX_FRAME_LAG] = {};
+	uint32_t frame_index = 0;
+	// Initialize to 0 because we don't want it to be used before we initialize and read the config
+	// (this value must stay constant throghout VulkanContext's & RenderingDevice's lifetime).
+	uint32_t frame_count = 0;
+	// See swapchainImageCount.
+	uint32_t swapchain_desired_count = 0;
+	VkFence fences[MAX_FRAME_LAG] = {};
 	VkPhysicalDeviceMemoryProperties memory_properties;
 	VkPhysicalDeviceFeatures physical_device_features;
 
@@ -154,7 +159,7 @@ private:
 		VkSwapchainKHR swapchain = VK_NULL_HANDLE;
 		SwapchainImageResources *swapchain_image_resources = VK_NULL_HANDLE;
 		VkPresentModeKHR presentMode = VK_PRESENT_MODE_FIFO_KHR;
-		VkSemaphore image_acquired_semaphores[FRAME_LAG];
+		VkSemaphore image_acquired_semaphores[MAX_FRAME_LAG] = {};
 		bool semaphore_acquired = false;
 		uint32_t current_buffer = 0;
 		int width = 0;
@@ -290,6 +295,9 @@ public:
 	int get_swapchain_image_count() const;
 	VkQueue get_graphics_queue() const;
 	uint32_t get_graphics_queue_family_index() const;
+
+	uint32_t get_frame_index() const { return frame_index; }
+	uint32_t get_frame_count() const { return frame_count; }
 
 	static void set_vulkan_hooks(VulkanHooks *p_vulkan_hooks) { vulkan_hooks = p_vulkan_hooks; };
 

--- a/platform/ios/vulkan_context_ios.mm
+++ b/platform/ios/vulkan_context_ios.mm
@@ -57,7 +57,8 @@ Error VulkanContextIOS::window_create(DisplayServer::WindowID p_window_id, Displ
 	return _window_create(p_window_id, p_vsync_mode, surface, p_width, p_height);
 }
 
-VulkanContextIOS::VulkanContextIOS() {}
+VulkanContextIOS::VulkanContextIOS() {
+}
 
 VulkanContextIOS::~VulkanContextIOS() {}
 


### PR DESCRIPTION
The original code had two bugs:

1. It assumed Swapchain count can be used for proper CPU/GPU synchronization (it's not)
2. It used a double buffer scheme (FRAME_LAG = 2) but the vkWaitForFences/vkResetFences calls were in the wrong order and in the wrong place
3. The swapchain bug forced a quad-buffer scheme with roughly 1 or 2 frames of wait; which hid all the issues

This commit gets rid of RenderingDeviceVulkan::frame_count & RenderingDeviceVulkan::frame which should've never existed and makes everything depend on VulkanContext::frame_index &
VulkanContext::FRAME_LAG

Add ability to tweak FRAME_LAG from within Project Settings Adds new setting display/window/vsync/buffer_count Adds new setting display/window/vsync/swapchain_count

See https://github.com/godotengine/godot/issues/80550 for details

------------------------------------------------------------------

Fix comment grammar
Use Godot's functions instead of std

------------------------------------------------------------------

Additionally handle inconsistent state when destroying windows: window.image_acquired_semaphores[i] contains uninitialized values.

This means that if VulkanContext::_update_swap_chain had failed early (this can happen for valid reasons and due to unexpected failures) then _clean_up_swap_chain will try to destroy an invalid handle. This fix always sets the handle to VK_NULL_HANDLE.

Likewise perform the checks in various other resources in _clean_up_swap_chain in case the resources were partially initialized and are now in an inconsistent state. The API should guarantee the call to be valid if the handle was VK_NULL_HANDLE, but I don't trust driver implementations to handle that case.

Affects #81670

<!--
Please target the `master` branch in priority.
PRs can target `3.x` if the same change was done in `master`, or is not relevant there.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.
You can mention in the description if the change is compatible with `3.x`.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
